### PR TITLE
新しめの Protobuf でコンパイルできるように修正

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,15 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 project(ssl-protos CXX)
+
+set(CMAKE_CXX_EXTENSIONS  OFF)
+set(CMAKE_CXX_STANDARD    17)
+set(CXX_STANDARD_REQUIRED ON)
 
 if(NOT Protobuf_FOUND)
   find_package(Protobuf REQUIRED)
 endif()
 
-if(NOT EXISTS ${Protobuf_PROTOC_EXECUTABLE})
+if(NOT TARGET protobuf::protoc)
   message(FATAL_ERROR "Could not find Protobuf Compiler!")
 endif()
 

--- a/ssl-protos/CMakeLists.txt
+++ b/ssl-protos/CMakeLists.txt
@@ -1,4 +1,35 @@
-file(GLOB_RECURSE PROTO_FILES *.proto)
-protobuf_generate_cpp(PROTO_CC PROTO_H ${PROTO_FILES})
-add_library(ssl-protos-obj OBJECT ${PROTO_CC} ${PROTO_H})
+set(proto_files
+  gc_api.proto
+  gc_change.proto
+  gc_ci.proto
+  gc_common.proto
+  gc_engine.proto
+  gc_engine_config.proto
+  gc_game_event.proto
+  gc_geometry.proto
+  gc_rcon.proto
+  gc_rcon_autoref.proto
+  gc_rcon_remotecontrol.proto
+  gc_rcon_team.proto
+  gc_referee_message.proto
+  gc_state.proto
+  grsim_command.proto
+  grsim_packet.proto
+  grsim_replacement.proto
+  grsim_robotstatus.proto
+  simulation_config.proto
+  simulation_control.proto
+  simulation_error.proto
+  simulation_robot_control.proto
+  simulation_robot_feedback.proto
+  simulation_synchronous.proto
+  vision_detection.proto
+  vision_detection_tracked.proto
+  vision_geometry.proto
+  vision_wrapper.proto
+  vision_wrapper_tracked.proto
+)
+
+protobuf_generate(LANGUAGE cpp OUT_VAR generated_files PROTOS ${proto_files})
+add_library(ssl-protos-obj OBJECT ${generated_files})
 target_link_libraries(ssl-protos-obj protobuf::libprotobuf)


### PR DESCRIPTION
- CMake のオプション `-D <PackageName>_ROOT=...` を使えるように `cmake_minimum_required` を 3.12 に上げる
  https://cmake.org/cmake/help/v3.12/variable/PackageName_ROOT.html#variable:%3CPackageName%3E_ROOT

- 新しめの Protobuf (CMake にバンドルされている `FindProtobuf.cmake` がうまく動いてくれないケース) で有効な CMake のオプション `-D CMAKE_FIND_PACKAGE_PREFER_CONFIG=ON` した場合でも使えるように `protobuf_generate_cpp` のかわりに `protobuf_generate` を使う
  https://cmake.org/cmake/help/v3.16/variable/CMAKE_FIND_PACKAGE_PREFER_CONFIG.html?highlight=cmake_find_package_prefer_config

- Protobuf のバージョンによっては `static_assert(PROTOBUF_CPLUSPLUS_MIN(201402L), "Protobuf only supports C++14 and newer.");` で落ちるので常に C++17 でビルドする

- CMake 公式の推奨しない `file(GLOB)` をやめる
  https://cmake.org/cmake/help/v3.16/command/file.html#glob